### PR TITLE
Improve dashboard UI and add chart insights

### DIFF
--- a/client/src/components/ChartView.tsx
+++ b/client/src/components/ChartView.tsx
@@ -1,12 +1,32 @@
 import { Bar, Line, Pie } from 'react-chartjs-2'
-import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, PointElement, LineElement, ArcElement, Tooltip, Legend } from 'chart.js'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  ArcElement,
+  Tooltip,
+  Legend
+} from 'chart.js'
 import { FC } from 'react'
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, PointElement, LineElement, ArcElement, Tooltip, Legend)
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  ArcElement,
+  Tooltip,
+  Legend
+)
 
 type ChartData = {
   id: string
   title: string
+  description: string
   type: 'bar' | 'line' | 'pie'
   data: any
 }
@@ -18,4 +38,4 @@ const ChartView: FC<{ chart: ChartData }> = ({ chart }) => {
   return null
 }
 
-export default ChartView 
+export default ChartView

--- a/client/src/pages/ChartDetailPage.tsx
+++ b/client/src/pages/ChartDetailPage.tsx
@@ -5,6 +5,7 @@ import ChartView from '../components/ChartView'
 type ChartData = {
   id: string
   title: string
+  description: string
   type: 'bar' | 'line' | 'pie'
   data: any
 }
@@ -22,9 +23,12 @@ export default function ChartDetailPage() {
   if (!chart) return <div>로딩 중...</div>
 
   return (
-    <div>
-      <h2>{chart.title}</h2>
-      <ChartView chart={chart} />
+    <div className="max-w-3xl mx-auto p-6 space-y-4">
+      <h2 className="text-2xl font-bold">{chart.title}</h2>
+      <div className="card p-4">
+        <ChartView chart={chart} />
+      </div>
+      <p className="text-neutral-700">{chart.description}</p>
     </div>
   )
-} 
+}

--- a/client/src/pages/MainPage.tsx
+++ b/client/src/pages/MainPage.tsx
@@ -17,15 +17,19 @@ export default function MainPage() {
   }, [])
 
   return (
-    <div>
-      <h1>대시보드 차트 목록</h1>
-      <ul>
+    <div className="max-w-3xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">대시보드 차트 목록</h1>
+      <ul className="grid gap-4 md:grid-cols-2">
         {charts.map(chart => (
-          <li key={chart.id} style={{ cursor: 'pointer' }} onClick={() => navigate(`/charts/${chart.id}`)}>
-            {chart.title}
+          <li
+            key={chart.id}
+            className="card cursor-pointer hover:bg-primary-50"
+            onClick={() => navigate(`/charts/${chart.id}`)}
+          >
+            <h2 className="font-semibold">{chart.title}</h2>
           </li>
         ))}
       </ul>
     </div>
   )
-} 
+}

--- a/server/src/services/dashboardService.ts
+++ b/server/src/services/dashboardService.ts
@@ -8,6 +8,7 @@ type ChartDataset = {
 type ChartData = {
   id: string
   title: string
+  description: string
   type: 'bar' | 'line' | 'pie'
   data: {
     labels: string[]
@@ -48,16 +49,21 @@ export function createDashboardService(): DashboardService {
         value: Number(pkg['총 릴리즈 수'])
       }))
 
+    const top = data[0]
+
     return {
       id: 'package-releases',
       title: '패키지별 릴리즈 수',
+      description: `가장 많이 릴리즈된 패키지는 ${top.name}로 총 ${top.value}회 릴리즈되었습니다.`,
       type: 'bar',
       data: {
         labels: data.map(d => d.name),
-        datasets: [{
-          label: '릴리즈 수',
-          data: data.map(d => d.value)
-        }]
+        datasets: [
+          {
+            label: '릴리즈 수',
+            data: data.map(d => d.value)
+          }
+        ]
       }
     }
   }
@@ -71,16 +77,21 @@ export function createDashboardService(): DashboardService {
         value: Number(pkg['평균 릴리즈 주기(근무일 기준)'])
       }))
 
+    const max = data.reduce((a, b) => (a.value > b.value ? a : b))
+
     return {
       id: 'release-cycle',
       title: '릴리즈 주기 분포',
+      description: `${max.name} 패키지의 릴리즈 주기가 가장 길며 평균 ${max.value} 근무일입니다.`,
       type: 'bar',
       data: {
         labels: data.map(d => d.name),
-        datasets: [{
-          label: '평균 릴리즈 주기 (근무일)',
-          data: data.map(d => d.value)
-        }]
+        datasets: [
+          {
+            label: '평균 릴리즈 주기 (근무일)',
+            data: data.map(d => d.value)
+          }
+        ]
       }
     }
   }
@@ -93,35 +104,38 @@ export function createDashboardService(): DashboardService {
       weekend: Number(repo['주말 릴리즈 비율(%)'])
     }))
 
+    const prereleaseAvg = data.reduce((sum, repo) => sum + repo.prerelease, 0) / data.length
+    const weekendAvg = data.reduce((sum, repo) => sum + repo.weekend, 0) / data.length
+
     return {
       id: 'release-types',
       title: '릴리즈 유형 분포',
+      description: `평균 프리릴리즈 비율은 ${prereleaseAvg.toFixed(1)}%, 주말 릴리즈 비율은 ${weekendAvg.toFixed(1)}%입니다.`,
       type: 'pie',
       data: {
         labels: ['프리릴리즈', '주말 릴리즈', '일반 릴리즈'],
-        datasets: [{
-          label: '비율 (%)',
-          data: [
-            data.reduce((sum, repo) => sum + repo.prerelease, 0) / data.length,
-            data.reduce((sum, repo) => sum + repo.weekend, 0) / data.length,
-            100 - (data.reduce((sum, repo) => sum + repo.prerelease + repo.weekend, 0) / data.length)
-          ]
-        }]
+        datasets: [
+          {
+            label: '비율 (%)',
+            data: [
+              data.reduce((sum, repo) => sum + repo.prerelease, 0) / data.length,
+              data.reduce((sum, repo) => sum + repo.weekend, 0) / data.length,
+              100 -
+                data.reduce((sum, repo) => sum + repo.prerelease + repo.weekend, 0) / data.length
+            ]
+          }
+        ]
       }
     }
   }
 
   return {
     async getCharts() {
-      return [
-        createPackageReleaseChart(),
-        createReleaseCycleChart(),
-        createReleaseTypeChart()
-      ]
+      return [createPackageReleaseChart(), createReleaseCycleChart(), createReleaseTypeChart()]
     },
     async getChartById(id: string) {
       const charts = await this.getCharts()
       return charts.find(chart => chart.id === id) || null
     }
   }
-} 
+}


### PR DESCRIPTION
## Summary
- style chart list on the main page
- style chart detail page
- extend chart objects with a `description` field and provide simple insights

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454ccdbb2083219db14d0a997e9728